### PR TITLE
Fix `dmenu` argument on `generic_entry`

### DIFF
--- a/wofi.py
+++ b/wofi.py
@@ -635,7 +635,7 @@ class Wofi(object):
 
         # Keep going until we get something valid.
         while True:
-            args = [self.wofi_exe, '-dmenu', '-p', prompt]
+            args = [self.wofi_exe, '--dmenu', '-p', prompt]
 
             # Add any error to the given message.
             msg = message or ""


### PR DESCRIPTION
The `--dmenu` argument on `generic_entry` was not being properly called, which resulted in a warning being printed out. This fixes the command call.